### PR TITLE
Update mroute to capture all known lines and raise an error if a line is not matched by the parser

### DIFF
--- a/templates/cisco_ios_show_ip_mroute.template
+++ b/templates/cisco_ios_show_ip_mroute.template
@@ -16,4 +16,11 @@ Start
   ^\((\*|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}),\s(\*|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\) -> Continue.Record
   ^\(${MULTICAST_SOURCE_IP},\s${MULTICAST_GROUP_IP}\),\s${UP_TIME}\/${EXPIRATION_TIME}(,\sRP\s${RENDEZVOUS_POINT})?,\sflags:\s${FLAGS}
   ^\s+Incoming\sinterface:\s${INCOMING_INTERFACE},\sRPF\snbr\s${REVERSE_PATH_FORWARDING_NEIGHBOUR_IP}(,\s${REGISTERING})?
+  ^\s+Outgoing\s+interface\s+list:(?:\s+Null|)\s*$$
   ^\s+${OUTGOING_INTERFACE},\s${FORWARD_MODE},\s${OUTGOING_MULTICAST_UP_TIME}\/${OUTGOING_MULTICAST_EXPIRATION_TIME}
+  ^\s*$$
+  ^IP\s+Multicast\s+(?:Forwarding|Routing)
+  ^.*[Ff]lags
+  ^\s+\S+\s+-\s+
+  ^\s+(?:Timers|Interface\s+state):
+  ^. -> Error

--- a/tests/cisco_ios/show_ip_mroute/cisco_ios_show_ip_mroute2.parsed
+++ b/tests/cisco_ios/show_ip_mroute/cisco_ios_show_ip_mroute2.parsed
@@ -1,17 +1,2 @@
 ---
-parsed_sample:
-
-- multicast_source_ip: ""
-  multicast_group_ip: ""
-  up_time: ""
-  expiration_time: ""
-  rendezvous_point: ""
-  flags: ""
-  incoming_interface: ""
-  reverse_path_forwarding_neighbour_ip: ""
-  registering: ""
-  outgoing_interface: []
-  forward_mode: []
-  outgoing_multicast_up_time: []
-  outgoing_multicast_expiration_time: []
-
+parsed_sample: []


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT
<!--- Name of the template, os and command  -->
cisco_ios_show_ip_mroute

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
New templates require a catchall Error line to ensure that all appropriate data is known and captured
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
